### PR TITLE
feat: 댓글 업데이트/삭제 기능

### DIFF
--- a/src/app/detail/[id]/page.tsx
+++ b/src/app/detail/[id]/page.tsx
@@ -1,9 +1,26 @@
 import PlaceDetail from '@/components/detail/PlaceDetail';
 import { fetchOneCampSite } from '@/app/api/campingApi';
 import CommentSection from '@/components/detail/CommentSection';
+import { Metadata } from 'next';
 
 // ISR 설정: 페이지가 1시간마다 재생성
-export const revalidate = 3600; // 1시간
+// export const revalidate = 3600; // 1시간
+
+export const generateMetadata = async ({
+  params,
+}: PlaceDetailPageProps): Promise<Metadata> => {
+  const facltNm = decodeURIComponent(params.id);
+
+  return {
+    title: `BonFire - ${facltNm} 상세 정보`,
+    description: `${facltNm}의 캠핑장 상세 정보를 확인하세요.`,
+    openGraph: {
+      title: `BonFire - ${facltNm} 상세 정보`,
+      description: `${facltNm}의 캠핑장 상세 정보를 확인하세요.`,
+      url: `http://localhost:3000/detail/${params.id}`,
+    },
+  };
+}
 
 type PlaceDetailPageProps = {
   params: {

--- a/src/app/detail/actions.ts
+++ b/src/app/detail/actions.ts
@@ -39,3 +39,15 @@ export const fetchComments = async (placeName: string) => {
     user: comment.users, // 닉네임과 프로필 이미지 첨부
   }));
 };
+
+// 댓글 삭제 기능
+export const deleteComment = async (commentId: string) => {
+  const supabase = await createClient();
+
+  const { error } = await supabase.from('comments').delete().eq('id', commentId);
+
+  if (error) {
+    throw new Error(`댓글 삭제에 실패했습니다: ${error!.message}`);
+  }
+};
+

--- a/src/app/detail/actions.ts
+++ b/src/app/detail/actions.ts
@@ -6,7 +6,6 @@ import { createClient } from '@/utils/supabase/server';
 // 상세 페이지 댓글 관련 actions 모음
 // -> 댓글 기능을 상세 페이지에서만 사용
 type CommentsInsert = Database['public']['Tables']['comments']['Insert'];
-type CommentsRow = Tables<'comments'>;
 
 // 댓글 추가 받아온 formData 사용
 export const addComment = async (comment: CommentsInsert) => {
@@ -44,10 +43,24 @@ export const fetchComments = async (placeName: string) => {
 export const deleteComment = async (commentId: string) => {
   const supabase = await createClient();
 
-  const { error } = await supabase.from('comments').delete().eq('id', commentId);
+  const { error } = await supabase
+    .from('comments')
+    .delete()
+    .eq('id', commentId);
 
   if (error) {
     throw new Error(`댓글 삭제에 실패했습니다: ${error!.message}`);
+  }
+};
+
+// 댓글 수정 기능
+export const updateComment = async (commentId: string, content: string) => {
+  const supabase = await createClient();
+
+  const { error } = await supabase.from('comments').update({ content }).eq('id', commentId);
+  
+  if (error) {
+    throw new Error(`댓글 수정에 실패했습니다: ${error!.message}`);
   }
 };
 

--- a/src/components/detail/CommentForm.tsx
+++ b/src/components/detail/CommentForm.tsx
@@ -21,7 +21,7 @@ const CommentForm = ({ placeName, commentNum }: CommentFormProps) => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    // Check for empty comments
+    // 댓글이 비어 있는 경우 추가 X
     if (!comment.trim()) {
       alert('댓글 입력창이 비어있습니다.');
       return;
@@ -48,18 +48,15 @@ const CommentForm = ({ placeName, commentNum }: CommentFormProps) => {
         <p>{`(${commentNum})`}</p>
       </div>
 
-      <hr className="border border-gray-500 my-4" />
-      <div className="mb-4">
-        <CommentInput
-          disabled={!currentUser}
-          placeholder={
-            !currentUser ? '로그인이 필요합니다' : '댓글을 입력하세요'
-          }
-          value={comment}
-          onChange={(e) => setComment(e.target.value)}
-          required
-        />
-      </div>
+      <hr className="border border-gray-500 mt-4" />
+      <CommentInput
+        disabled={!currentUser}
+        type="text"
+        placeholder={!currentUser ? '로그인이 필요합니다' : '댓글을 입력하세요'}
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        required
+      />
       {currentUser && (
         <button
           type="submit"

--- a/src/components/detail/CommentForm.tsx
+++ b/src/components/detail/CommentForm.tsx
@@ -4,9 +4,8 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { MessageSquare } from 'lucide-react';
 import { CommentInput } from './CommentInput';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { addComment } from '@/app/detail/actions';
 import { useAuthStore } from '@/store/authStore';
+import { useComments } from '@/hooks/comment/useComment';
 
 type CommentFormProps = {
   placeName: string;
@@ -16,46 +15,29 @@ type CommentFormProps = {
 const CommentForm = ({ placeName, commentNum }: CommentFormProps) => {
   const { user: currentUser } = useAuthStore();
   const [comment, setComment] = useState('');
-  const queryClient = useQueryClient();
+  const { addComment, isAdding } = useComments(placeName);
   const router = useRouter();
 
-  const mutation = useMutation({
-    mutationFn: async () => {
-      // TODO: 에러 처리보다는 로그인으로 유도하는 것이 필요해보입니다
-      // 인증된 유저가 아닌 경우 에러 처리
-      if (!currentUser) {
-        throw new Error('댓글 입력을 위해서는 로그인이 필요합니다');
-      }
-
-      // DB로 전송 (서버 액션)
-      await addComment({
-        content: comment,
-        place_name: placeName,
-        user_id: currentUser[0].id,
-      });
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['comments', placeName] });
-      setComment('');
-      router.refresh();
-    },
-    onError: (error) => {
-      console.error('댓글 등록 실패:', error);
-      // TODO: alert 말고 다른것으로 바꾸기
-      alert('댓글 등록에 실패했습니다.');
-    },
-  });
-
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    // 댓글 (빈 댓글 받으면 안됨)
+    // Check for empty comments
     if (!comment.trim()) {
-      // TODO: alert 말고 다른 것
       alert('댓글 입력창이 비어있습니다.');
       return;
     }
-    mutation.mutate();
+
+    if (currentUser) {
+      addComment(
+        { content: comment, userId: currentUser[0].id },
+        {
+          onSuccess: () => {
+            setComment('');
+            router.refresh();
+          },
+        },
+      );
+    }
   };
 
   return (
@@ -70,7 +52,9 @@ const CommentForm = ({ placeName, commentNum }: CommentFormProps) => {
       <div className="mb-4">
         <CommentInput
           disabled={!currentUser}
-          placeholder={!currentUser? "로그인이 필요합니다" :"댓글을 입력하세요"}
+          placeholder={
+            !currentUser ? '로그인이 필요합니다' : '댓글을 입력하세요'
+          }
           value={comment}
           onChange={(e) => setComment(e.target.value)}
           required
@@ -79,9 +63,12 @@ const CommentForm = ({ placeName, commentNum }: CommentFormProps) => {
       {currentUser && (
         <button
           type="submit"
-          className="bg-[#FFB200] px-4 py-2 rounded-lg text-white font-semibold place-self-end"
+          className={`px-4 py-2 rounded-lg text-white font-semibold place-self-end ${
+            isAdding ? 'bg-gray-400 cursor-not-allowed' : 'bg-[#FFB200]'
+          }`}
+          disabled={isAdding}
         >
-          {mutation.isPending ? '작성 중...' : '작성하기'}
+          {isAdding ? '작성 중...' : '작성하기'}
         </button>
       )}
     </form>

--- a/src/components/detail/CommentInput.tsx
+++ b/src/components/detail/CommentInput.tsx
@@ -8,13 +8,13 @@ const CommentInput = React.forwardRef<HTMLInputElement, React.ComponentProps<"in
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-          className
+          'flex h-9 w-full rounded-xl border border-input bg-transparent my-4 px-3 py-7 leading-6 shadow-sm transition-colors file:border-0 file:bg-transparent file:text-2xl file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+          className,
         )}
         ref={ref}
         {...props}
       />
-    )
+    );
   }
 )
 CommentInput.displayName = "Input"

--- a/src/components/detail/CommentItem.tsx
+++ b/src/components/detail/CommentItem.tsx
@@ -1,20 +1,35 @@
 'use client';
 
+import { useComments } from '@/hooks/comment/useComment';
 import { useAuthStore } from '@/store/authStore';
 import { PenLine, Trash2 } from 'lucide-react';
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 type CommentProps = {
   userId: string;
   nickname: string;
   profileImage: string | null;
   content: string;
+  commentId: string;
+  placeName: string;
 };
 
-const Comment = ({ userId, nickname, profileImage, content }: CommentProps) => {
+const Comment = ({ userId, nickname, profileImage, content, commentId, placeName }: CommentProps) => {
   const { user: currentUser } = useAuthStore();
+  const { deleteComment, isDeleting } = useComments(placeName);
   const allowedToChange = currentUser?.[0]?.id === userId;
+  const router = useRouter();
+
+  const handleDelete = () => {
+    if (confirm('정말로 이 댓글을 삭제하시겠습니까?')) {
+      deleteComment(commentId, {
+        onSuccess: () => {
+          router.refresh();
+        } 
+      });
+    }
+  };
 
   return (
     <div className="flex flex-col">
@@ -40,7 +55,7 @@ const Comment = ({ userId, nickname, profileImage, content }: CommentProps) => {
             <button>
               <PenLine />
             </button>
-            <button>
+            <button onClick={handleDelete} disabled={isDeleting}>
               <Trash2 />
             </button>
           </>

--- a/src/components/detail/CommentList.tsx
+++ b/src/components/detail/CommentList.tsx
@@ -3,9 +3,10 @@ import { Comment } from '@/types/Comment';
 
 type CommentsProps = {
   commentList: Comment[];
+  placeName: string;
 };
 
-const CommentList = ({ commentList }: CommentsProps) => {
+const CommentList = ({ commentList, placeName }: CommentsProps) => {
   return (
     <div>
       {commentList.map((comment) => (
@@ -15,6 +16,8 @@ const CommentList = ({ commentList }: CommentsProps) => {
           profileImage={comment.user?.profile_image || null}
           content={comment.content}
           userId={comment.user_id}
+          commentId={comment.id}
+          placeName={placeName}
         />
       ))}
     </div>

--- a/src/components/detail/CommentSection.tsx
+++ b/src/components/detail/CommentSection.tsx
@@ -18,7 +18,7 @@ const CommentSection = async ({facltNm }: CommentSectionProps) => {
         commentNum={commentList.length}
       />
       <Suspense fallback={<CommentListSkeleton />}>
-        <CommentList commentList={commentList} />
+        <CommentList commentList={commentList} placeName={facltNm} />
       </Suspense>
     </div>
   );

--- a/src/components/detail/DetailMap.tsx
+++ b/src/components/detail/DetailMap.tsx
@@ -41,7 +41,10 @@ const DetailMap = ({
           marker={{ position: { lat: latitude, lng: longitude } }}
         />
       ) : (
-        <p>로딩 중입니다.</p>
+        <div
+          style={{ width, height }}
+          className="animate-pulse bg-gray-300"
+        ></div>
       )}
     </>
   );

--- a/src/components/detail/PlaceDetail.tsx
+++ b/src/components/detail/PlaceDetail.tsx
@@ -11,7 +11,7 @@ const PlaceDetail = ({ details }: PlaceDetailProps) => {
   return (
     <div className="flex flex-col items-center sm:flex-row gap-8 border justify-between align-center border-black rounded-xl px-10 py-8 mb-6">
       {/* 장소 상세 정보 */}
-      <div className="flex flex-col justify-center">
+      <div className="flex flex-col justify-center sm:w-1/2">
         <h2 className="text-2xl font-semibold mb-4">{details.facltNm}</h2>
         <p className="mb-2 text-gray-500">{details.addr1}</p>
         <p className="mb-2 text-gray-500">

--- a/src/hooks/comment/useComment.ts
+++ b/src/hooks/comment/useComment.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { addComment, deleteComment } from '@/app/detail/actions';
+import { addComment, deleteComment, updateComment } from '@/app/detail/actions';
 
 export const useComments = (placeName: string) => {
   const queryClient = useQueryClient();
@@ -35,7 +35,7 @@ export const useComments = (placeName: string) => {
       await deleteComment(commentId);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['comments', placeName] }); 
+      queryClient.invalidateQueries({ queryKey: ['comments', placeName] });
     },
     onError: (error) => {
       console.error('댓글 삭제 실패:', error);
@@ -44,12 +44,33 @@ export const useComments = (placeName: string) => {
     },
   });
 
+  // 수정 mutation
+  const updateCommentMutation = useMutation({
+    mutationFn: async ({
+      commentId,
+      content,
+    }: {
+      commentId: string;
+      content: string;
+    }) => {
+      await updateComment(commentId, content);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments', placeName] });
+    },
+    onError: (error) => {
+      console.error('댓글 수정 실패:', error);
+      // TODO: alert를 바꾸도록
+      alert('댓글 수정에 실패했습니다.');
+    },
+  });
+
   return {
     addComment: addCommentMutation.mutate,
     isAdding: addCommentMutation.isPending,
-    addError: addCommentMutation.error,
     deleteComment: deleteCommentMutation.mutate,
     isDeleting: deleteCommentMutation.isPending,
-    deleteError: deleteCommentMutation.error,
+    update: updateCommentMutation.mutate,
+    isUpdating: updateCommentMutation.isPending,
   };
 };

--- a/src/hooks/comment/useComment.ts
+++ b/src/hooks/comment/useComment.ts
@@ -70,7 +70,7 @@ export const useComments = (placeName: string) => {
     isAdding: addCommentMutation.isPending,
     deleteComment: deleteCommentMutation.mutate,
     isDeleting: deleteCommentMutation.isPending,
-    update: updateCommentMutation.mutate,
+    updateComment: updateCommentMutation.mutate,
     isUpdating: updateCommentMutation.isPending,
   };
 };

--- a/src/hooks/comment/useComment.ts
+++ b/src/hooks/comment/useComment.ts
@@ -1,0 +1,55 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { addComment, deleteComment } from '@/app/detail/actions';
+
+export const useComments = (placeName: string) => {
+  const queryClient = useQueryClient();
+
+  // 추가 mutation
+  const addCommentMutation = useMutation({
+    mutationFn: async ({
+      content,
+      userId,
+    }: {
+      content: string;
+      userId: string;
+    }) => {
+      await addComment({
+        content,
+        place_name: placeName,
+        user_id: userId,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments', placeName] });
+    },
+    onError: (error) => {
+      console.error('댓글 등록 실패:', error);
+      // TODO: alert를 바꾸도록
+      alert('댓글 등록에 실패했습니다.');
+    },
+  });
+
+  // 삭제 mutation
+  const deleteCommentMutation = useMutation({
+    mutationFn: async (commentId: string) => {
+      await deleteComment(commentId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments', placeName] }); 
+    },
+    onError: (error) => {
+      console.error('댓글 삭제 실패:', error);
+      // TODO: alert를 바꾸도록
+      alert('댓글 삭제에 실패했습니다.');
+    },
+  });
+
+  return {
+    addComment: addCommentMutation.mutate,
+    isAdding: addCommentMutation.isPending,
+    addError: addCommentMutation.error,
+    deleteComment: deleteCommentMutation.mutate,
+    isDeleting: deleteCommentMutation.isPending,
+    deleteError: deleteCommentMutation.error,
+  };
+};


### PR DESCRIPTION
**댓글의 업데이트/삭제 기능을 추가하였습니다.**

기능:
* 로그인한 유저는 본인의 댓글을 수정할 수 있습니다.
* 로그인한 유저는 본인의 댓글을 삭제할 수 있습니다.
* 수정/삭제 된 댓글의  UI 업데이트도 잘 이루어집니다.
* 비회원은 댓글을 입력할 수 없습니다. 수정도 안됩니다.

그 외 작업
* 좋아요 버튼의 위치를 중앙에 오도록 수정했습니다.
* 댓글폼의 인풋 창의 높이를 조정했습니다.
* 정적 지도의 마커를 커스텀으로 할 수 있는 조사했습니다만, 지원하지 않는 것으로 보입니다.

향후 상세 페이지에 필요한 작업:
* 비회원은 총 좋아요 수를 보지 못하는 버그 발견 -> 수정 필요
* 댓글은 시간순으로 정리하여 최신것부터 보여줄 필요가 있습니다.
* 현재는 수정을 하면 생성시간과 업데이트 시간이 같아지는 문제가 있어, 수정시간만 변경되도록 변경이 필요합니다.
* alert 그만쓰고 sweetalert으로 바꿔줘야 합니다.